### PR TITLE
Fix missing re import in data_reader

### DIFF
--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -6,6 +6,7 @@ import yt_dlp
 import io
 import webvtt
 import ffmpeg
+import re
 
 
 def video2audio(video, audio_format, tmp_dir):


### PR DESCRIPTION
## Summary
- fix missing `re` import in `data_reader`

## Testing
- `make lint` *(fails: Library stubs not installed)*
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68621e541720832fbfb3e8aee7acd226