### PR TITLE
Fix re import for YtDlpDownloader

### DIFF
--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -181,6 +181,7 @@ class YtDlpDownloader:
         self.specify_codec = False
 
     def __call__(self, url):
+        import re  # ensure regex module is available in multiprocessing context
         modality_paths = {}
         clip_span = None
 


### PR DESCRIPTION
## Summary
- ensure the `re` module is available when the downloader runs in subprocesses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862239550ac832fb1c8813098ecc542